### PR TITLE
BOT: payloadのdocstringを1層分展開して表示するように

### DIFF
--- a/libs/bot/aiotraq_bot/models/common.py
+++ b/libs/bot/aiotraq_bot/models/common.py
@@ -16,10 +16,10 @@ class UserPayload(BaseModel):
     """ユーザー情報ペイロード
 
     Attributes:
-        id (str): ユーザーUUId
+        id (str): ユーザーUUID
         name (str): ユーザーのtraQ Id
         displayName (str): ユーザーの表示名
-        iconId (str): ユーザーアイコンのファイルUUId
+        iconId (str): ユーザーアイコンのファイルUUID
         bot (bool): ユーザーがBotかどうか
     """
 
@@ -34,10 +34,10 @@ class ChannelPayload(BaseModel):
     """チャンネル情報ペイロード
 
     Attributes:
-        id (str): チャンネルUUId
+        id (str): チャンネルUUID
         name (str): チャンネル名
         path (str): チャンネルパス
-        parentId (str): 親チャンネルのUUId, ルートチャンネルの場合は"00000000-0000-0000-0000-000000000000"
+        parentId (str): 親チャンネルのUUID, ルートチャンネルの場合は"00000000-0000-0000-0000-000000000000"
         creator (UserPayload): チャンネル作成者
         createdAt (datetime.datetime): チャンネル作成日時
         updatedAt (datetime.datetime): チャンネル更新日時
@@ -70,9 +70,9 @@ class MessagePayload(BaseModel):
     """メッセージ情報ペイロード
 
     Attributes:
-        id (str): メッセージUUId
+        id (str): メッセージUUID
         user (UserPayload): メッセージ投稿者
-        channelId (str): 投稿先チャンネルUUId
+        channelId (str): 投稿先チャンネルUUID
         text (str): 生メッセージ本文
         plainText (str): メッセージ本文(埋め込み情報・改行なし)
         embedded (list[EmbeddedInfoPayload]): メッセージ埋め込み情報の配列
@@ -94,8 +94,8 @@ class MessageStampPayload(BaseModel):
     """メッセージスタンプ情報
 
     Attributes:
-        stampId (str): スタンプUUId
-        userId (str): スタンプを押したユーザーUUId
+        stampId (str): スタンプUUID
+        userId (str): スタンプを押したユーザーUUID
         count (int): このユーザーによって押されたこのスタンプの数
         createdAt (datetime.datetime): 最初にスタンプが押された日時
         updatedAt (datetime.datetime): 最後にスタンプが押された日時
@@ -112,8 +112,8 @@ class GroupMemberPayload(BaseModel):
     """グループメンバー情報ペイロード
 
     Attributes:
-        groupId (str): グループUUId
-        userId (str): ユーザーUUId
+        groupId (str): グループUUID
+        userId (str): ユーザーUUID
     """
 
     groupId: str
@@ -121,7 +121,12 @@ class GroupMemberPayload(BaseModel):
 
 
 class UserGroupAdminPayload(GroupMemberPayload):
-    """グループ管理者情報ペイロード"""
+    """グループ管理者情報ペイロード
+
+    Attributes:
+        groupId (str): グループUUID
+        userId (str): ユーザーUUID
+    """
 
     pass
 
@@ -130,8 +135,8 @@ class UserGroupMemberPayload(BaseModel):
     """グループメンバー(のより詳細な)情報ペイロード
 
     Attributes:
-        groupId (str): グループUUId
-        userId (str): ユーザーUUId
+        groupId (str): グループUUID
+        userId (str): ユーザーUUID
         role (str): メンバーの役割
     """
 
@@ -144,11 +149,11 @@ class UserGroupPayload(BaseModel):
     """グループ情報ペイロード
 
     Attributes:
-        id (str): グループUUId
+        id (str): グループUUID
         name (str): グループ名
         description (str): グループの説明
         type (str): グループの種類
-        icon (str): グループアイコンのファイルUUId
+        icon (str): グループアイコンのファイルUUID
         admins (list[UserGroupAdminPayload]): グループ管理者の配列
         members (list[UserGroupMemberPayload]): グループメンバーの配列
         createdAt (datetime.datetime): グループ作成日時

--- a/libs/bot/aiotraq_bot/models/event.py
+++ b/libs/bot/aiotraq_bot/models/event.py
@@ -12,7 +12,11 @@ from .common import (
 
 
 class PingPayload(BasePayload):
-    """PINGイベントペイロード"""
+    """PINGイベントペイロード
+
+    Attributes:
+        eventTime (datetime.datetime): イベント発生日時
+    """
 
     pass
 
@@ -21,7 +25,15 @@ class JoinedPayload(BasePayload):
     """JOINEDイベントペイロード
 
     Attributes:
+        eventTime (datetime.datetime): イベント発生日時
         channel (ChannelPayload): 参加したチャンネル
+            id (str): チャンネルUUID
+            name (str): チャンネル名
+            path (str): チャンネルパス
+            parentId (str): 親チャンネルのUUID, ルートチャンネルは"00000000-0000-0000-0000-000000000000"
+            creator (UserPayload): チャンネル作成者
+            createdAt (datetime.datetime): チャンネル作成日時
+            updatedAt (datetime.datetime): チャンネル更新日時
     """
 
     channel: ChannelPayload
@@ -31,7 +43,15 @@ class LeftPayload(BasePayload):
     """LEFTイベントペイロード
 
     Attributes:
+        eventTime (datetime.datetime): イベント発生日時
         channel (ChannelPayload): 退出したチャンネル
+            id (str): チャンネルUUID
+            name (str): チャンネル名
+            path (str): チャンネルパス
+            parentId (str): 親チャンネルのUUID, ルートチャンネルは"00000000-0000-0000-0000-000000000000"
+            creator (UserPayload): チャンネル作成者
+            createdAt (datetime.datetime): チャンネル作成日時
+            updatedAt (datetime.datetime): チャンネル更新日時
     """
 
     channel: ChannelPayload
@@ -41,7 +61,16 @@ class MessageCreatedPayload(BasePayload):
     """MESSAGE_CREATEDイベントペイロード
 
     Attributes:
+        eventTime (datetime.datetime): イベント発生日時
         message (MessagePayload): 投稿されたメッセージ
+            id (str): メッセージUUID
+            user (UserPayload): メッセージ投稿者
+            channelId (str): 投稿先チャンネルUUID
+            text (str): 生メッセージ本文
+            plainText (str): メッセージ本文(埋め込み情報・改行なし)
+            embedded (list[EmbeddedInfoPayload]): メッセージ埋め込み情報の配列
+            createdAt (datetime.datetime): メッセージ投稿日時
+            updatedAt (datetime.datetime): メッセージ更新日時
     """
 
     message: MessagePayload
@@ -51,7 +80,16 @@ class MessageUpdatedPayload(BasePayload):
     """MESSAGE_UPDATEDイベントペイロード
 
     Attributes:
+        eventTime (datetime.datetime): イベント発生日時
         message (MessagePayload): 更新されたメッセージ
+            id (str): メッセージUUID
+            user (UserPayload): メッセージ投稿者
+            channelId (str): 投稿先チャンネルUUID
+            text (str): 生メッセージ本文
+            plainText (str): メッセージ本文(埋め込み情報・改行なし)
+            embedded (list[EmbeddedInfoPayload]): メッセージ埋め込み情報の配列
+            createdAt (datetime.datetime): メッセージ投稿日時
+            updatedAt (datetime.datetime): メッセージ更新日時
     """
 
     message: MessagePayload
@@ -73,7 +111,10 @@ class MessageDeletedPayload(BasePayload):
     """MESSAGE_DELETEDイベントペイロード
 
     Attributes:
+        eventTime (datetime.datetime): イベント発生日時
         message (DeletedMessage): 削除されたメッセージ
+            id (str): メッセージUUID
+            channelId (str): 投稿先チャンネルUUID
     """
 
     message: DeletedMessage
@@ -83,8 +124,14 @@ class BotMessageStampsUpdatedPayload(BasePayload):
     """BOT_MESSAGE_STAMPS_UPDATEDイベントペイロード
 
     Attributes:
+        eventTime (datetime.datetime): イベント発生日時
         messageId (str): スタンプの更新があったメッセージUUID
         stamps (list[MessageStampPayload]): メッセージに現在ついている全てのスタンプ
+            stampId (str): スタンプUUID
+            userId (str): スタンプを押したユーザーUUID
+            count (int): このユーザーによって押されたこのスタンプの数
+            createdAt (datetime.datetime): 最初にスタンプが押された日時
+            updatedAt (datetime.datetime): 最後にスタンプが押された日時
     """
 
     messageId: str
@@ -95,7 +142,16 @@ class DirectMessageCreatedPayload(BasePayload):
     """DIRECT_MESSAGE_CREATEDイベントペイロード
 
     Attributes:
+        eventTime (datetime.datetime): イベント発生日時
         message (MessagePayload): 投稿されたメッセージ
+            id (str): メッセージUUID
+            user (UserPayload): メッセージ投稿者
+            channelId (str): 投稿先チャンネルUUID
+            text (str): 生メッセージ本文
+            plainText (str): メッセージ本文(埋め込み情報・改行なし)
+            embedded (list[EmbeddedInfoPayload]): メッセージ埋め込み情報の配列
+            createdAt (datetime.datetime): メッセージ投稿日時
+            updatedAt (datetime.datetime): メッセージ更新日時
     """
 
     message: MessagePayload
@@ -105,7 +161,16 @@ class DirectMessageUpdatedPayload(BasePayload):
     """DIRECT_MESSAGE_UPDATEDイベントペイロード
 
     Attributes:
+        eventTime (datetime.datetime): イベント発生日時
         message (MessagePayload): 更新されたメッセージ
+            id (str): メッセージUUID
+            user (UserPayload): メッセージ投稿者
+            channelId (str): 投稿先チャンネルUUID
+            text (str): 生メッセージ本文
+            plainText (str): メッセージ本文(埋め込み情報・改行なし)
+            embedded (list[EmbeddedInfoPayload]): メッセージ埋め込み情報の配列
+            createdAt (datetime.datetime): メッセージ投稿日時
+            updatedAt (datetime.datetime): メッセージ更新日時
     """
 
     message: MessagePayload
@@ -129,7 +194,11 @@ class DirectMessageDeletedPayload(BasePayload):
     """DIRECT_MESSAGE_DELETEDイベントペイロード
 
     Attributes:
+        eventTime (datetime.datetime): イベント発生日時
         message (DeletedDirectMessage): 削除されたメッセージ
+            id (str): メッセージUUID
+            userId (str): DMの宛先ユーザーUUID
+            channelId (str): 投稿先チャンネルUUID
     """
 
     message: DeletedDirectMessage
@@ -139,7 +208,15 @@ class ChannelCreatedPayload(BasePayload):
     """CHANNEL_CREATEDイベントペイロード
 
     Attributes:
+        eventTime (datetime.datetime): イベント発生日時
         channel (ChannelPayload): 作成されたチャンネル
+            id (str): チャンネルUUID
+            name (str): チャンネル名
+            path (str): チャンネルパス
+            parentId (str): 親チャンネルのUUID, ルートチャンネルは"00000000-0000-0000-0000-000000000000"
+            creator (UserPayload): チャンネル作成者
+            createdAt (datetime.datetime): チャンネル作成日時
+            updatedAt (datetime.datetime): チャンネル更新日時
     """
 
     channel: ChannelPayload
@@ -149,9 +226,22 @@ class ChannelTopicChangedPayload(BasePayload):
     """CHANNEL_TOPIC_CHANGEDイベントペイロード
 
     Attributes:
+        eventTime (datetime.datetime): イベント発生日時
         channel (ChannelPayload): 変更されたチャンネル
+            id (str): チャンネルUUID
+            name (str): チャンネル名
+            path (str): チャンネルパス
+            parentId (str): 親チャンネルのUUID, ルートチャンネルは"00000000-0000-0000-0000-000000000000"
+            creator (UserPayload): チャンネル作成者
+            createdAt (datetime.datetime): チャンネル作成日時
+            updatedAt (datetime.datetime): チャンネル更新日時
         topic (str): 変更後のトピック
         updater (UserPayload): トピック更新者
+            id (str): ユーザーUUID
+            name (str): ユーザーのtraQ Id
+            displayName (str): ユーザーの表示名
+            iconId (str): ユーザーアイコンのファイルUUID
+            bot (bool): ユーザーがBotかどうか
     """
 
     channel: ChannelPayload
@@ -163,7 +253,13 @@ class UserCreatedPayload(BasePayload):
     """USER_CREATEDイベントペイロード
 
     Attributes:
+        eventTime (datetime.datetime): イベント発生日時
         user (UserPayload): 作成されたユーザー
+            id (str): ユーザーUUID
+            name (str): ユーザーのtraQ Id
+            displayName (str): ユーザーの表示名
+            iconId (str): ユーザーアイコンのファイルUUID
+            bot (bool): ユーザーがBotかどうか
     """
 
     user: UserPayload
@@ -173,10 +269,16 @@ class StampCreatedPayload(BasePayload):
     """STAMP_CREATEDイベントペイロード
 
     Attributes:
+        eventTime (datetime.datetime): イベント発生日時
         id (str): スタンプUUID
         name (str): スタンプ名
         fileId (str): スタンプ画像ファイルUUID
         creator (UserPayload): スタンプを作成したユーザー
+            id (str): ユーザーUUID
+            name (str): ユーザーのtraQ Id
+            displayName (str): ユーザーの表示名
+            iconId (str): ユーザーアイコンのファイルUUID
+            bot (bool): ユーザーがBotかどうか
     """
 
     id: str
@@ -189,6 +291,7 @@ class TagAddedPayload(BasePayload):
     """TAG_ADDEDイベントペイロード
 
     Attributes:
+        eventTime (datetime.datetime): イベント発生日時
         tagId (str): タグUUID
         tag (str): タグ名
     """
@@ -201,6 +304,7 @@ class TagRemovedPayload(BasePayload):
     """TAG_REMOVEDイベントペイロード
 
     Attributes:
+        eventTime (datetime.datetime): イベント発生日時
         tagId (str): タグUUID
         tag (str): タグ名
     """
@@ -213,7 +317,17 @@ class UserGroupCreatedPayload(BasePayload):
     """USER_GROUP_CREATEDイベントペイロード
 
     Attributes:
+        eventTime (datetime.datetime): イベント発生日時
         group (UserGroupPayload): 作成されたグループ
+            id (str): グループUUID
+            name (str): グループ名
+            description (str): グループの説明
+            type (str): グループの種類
+            icon (str): グループアイコンのファイルUUID
+            admins (list[UserGroupAdminPayload]): グループ管理者の配列
+            members (list[UserGroupMemberPayload]): グループメンバーの配列
+            createdAt (datetime.datetime): グループ作成日時
+            updatedAt (datetime.datetime): グループ更新日時
     """
 
     group: UserGroupPayload
@@ -223,6 +337,7 @@ class UserGroupUpdatedPayload(BasePayload):
     """USER_GROUP_UPDATEDイベントペイロード
 
     Attributes:
+        eventTime (datetime.datetime): イベント発生日時
         groupId (str): 更新されたグループUUID
     """
 
@@ -233,6 +348,7 @@ class UserGroupDeletedPayload(BasePayload):
     """USER_GROUP_DELETEDイベントペイロード
 
     Attributes:
+        eventTime (datetime.datetime): イベント発生日時
         groupId (str): 削除されたグループUUID
     """
 
@@ -243,7 +359,10 @@ class UserGroupMemberAddedPayload(BasePayload):
     """USER_GROUP_MEMBER_ADDEDイベントペイロード
 
     Attributes:
+        eventTime (datetime.datetime): イベント発生日時
         groupMember (GroupMemberPayload): 追加されたグループメンバー情報
+            groupId (str): グループUUID
+            userId (str): ユーザーUUID
     """
 
     groupMember: GroupMemberPayload
@@ -253,7 +372,10 @@ class UserGroupMemberUpdatedPayload(BasePayload):
     """USER_GROUP_MEMBER_UPDATEDイベントペイロード
 
     Attributes:
+        eventTime (datetime.datetime): イベント発生日時
         groupMember (GroupMemberPayload): 更新されたグループメンバー情報
+            groupId (str): グループUUID
+            userId (str): ユーザーUUID
     """
 
     groupMember: GroupMemberPayload
@@ -263,7 +385,10 @@ class UserGroupMemberRemovedPayload(BasePayload):
     """USER_GROUP_MEMBER_REMOVEDイベントペイロード
 
     Attributes:
+        eventTime (datetime.datetime): イベント発生日時
         groupMember (GroupMemberPayload): 削除されたグループメンバー情報
+            groupId (str): グループUUID
+            userId (str): ユーザーUUID
     """
 
     groupMember: GroupMemberPayload
@@ -273,7 +398,10 @@ class UserGroupAdminAddedPayload(BasePayload):
     """USER_GROUP_ADMIN_ADDEDイベントペイロード
 
     Attributes:
+        eventTime (datetime.datetime): イベント発生日時
         groupMember (UserGroupAdminPayload): 追加されたグループ管理者情報
+            groupId (str): グループUUID
+            userId (str): ユーザーUUID
     """
 
     groupMember: UserGroupAdminPayload
@@ -283,7 +411,10 @@ class UserGroupAdminRemovedPayload(BasePayload):
     """USER_GROUP_ADMIN_REMOVEDイベントペイロード
 
     Attributes:
+        eventTime (datetime.datetime): イベント発生日時
         groupMember (UserGroupAdminPayload): 削除されたグループ管理者情報
+            groupId (str): グループUUID
+            userId (str): ユーザーUUID
     """
 
     groupMember: UserGroupAdminPayload


### PR DESCRIPTION
channelの中身に何が入っているのか分かりにくい問題があったので1層分だけ展開して表示するようにした
例: 
```
channel (ChannelPayload): 退出したチャンネル
            id (str): チャンネルUUID
            name (str): チャンネル名
            path (str): チャンネルパス
            parentId (str): 親チャンネルのUUID, ルートチャンネルは"00000000-0000-0000-0000-000000000000"
            creator (UserPayload): チャンネル作成者
            createdAt (datetime.datetime): チャンネル作成日時
            updatedAt (datetime.datetime): チャンネル更新日時
```